### PR TITLE
Correct PriceOracleInterface and add PriceOracleMock

### DIFF
--- a/contracts/PriceOracleInterface.sol
+++ b/contracts/PriceOracleInterface.sol
@@ -1,7 +1,7 @@
 /* solhint-disable-next-line compiler-fixed */
 pragma solidity ^0.4.17;
 
-// Copyright 2017 OST.com Ltd.
+// Copyright 2018 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contracts/PriceOracleInterface.sol
+++ b/contracts/PriceOracleInterface.sol
@@ -37,15 +37,6 @@ contract PriceOracleInterface {
     /*
      * Functions
      */
-    /// @dev use this function to update oracle price
-    /// @param _price price
-    /// @return expirationHeight
-    function setPrice(
-        uint256 _price)
-        external
-        returns(
-        uint256);
-
     /// @dev Price is stored as fixed point integer value similar as wei unit.
     /// Use this variable in case decimal value need to be evaluated
     /// @return token decimals

--- a/contracts/PriceOracleMock.sol
+++ b/contracts/PriceOracleMock.sol
@@ -50,7 +50,8 @@ contract PriceOracleMock is PriceOracleInterface {
     /// @param _quoteCurrency quoteCurrency
     function PriceOracleMock(
         bytes3 _baseCurrency,
-        bytes3 _quoteCurrency
+        bytes3 _quoteCurrency,
+        uint256 _price
         )
         public
     {
@@ -58,21 +59,7 @@ contract PriceOracleMock is PriceOracleInterface {
         oracleQuoteCurrency = _quoteCurrency;
         // Initialize base currency
         oracleBaseCurrency = _baseCurrency;
-    }
-
-    /// @dev use this method to set price
-    /// @param _price price
-    /// @return uint256
-    function setPrice(
-        uint256 _price)
-        external
-        returns(
-        uint256)
-    {
-        // Assign the new value
         price = _price;
-
-        return 0;
     }
 
     /// @dev gets price

--- a/contracts/PriceOracleMock.sol
+++ b/contracts/PriceOracleMock.sol
@@ -1,7 +1,7 @@
 /* solhint-disable-next-line compiler-fixed */
 pragma solidity ^0.4.17;
 
-// Copyright 2017 OST.com Ltd.
+// Copyright 2018 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,40 +16,30 @@ pragma solidity ^0.4.17;
 // limitations under the License.
 //
 // ----------------------------------------------------------------------------
-// Utility Chain: PriceOracle
+// Utility Chain: PriceOracleMock
 //
 // http://www.simpletoken.org/
 //
 // --------------------------
 
-import "../OpsManaged.sol";
 import "./PriceOracleInterface.sol";
 
 
-/// @title PriceOracle - Accepts and exposes a price for a certain base currency in a certain quote currency.
-contract PriceOracle is OpsManaged, PriceOracleInterface {
+/// @title PriceOracleMock - Basic implementation of the PriceOracleInterface to aid testing Pricer
+contract PriceOracleMock is PriceOracleInterface {
 
     /*
      *  Constants
      */
-    /// Block expiry duration private constant variable
-    // The constant value is set in block numbers which is equivalent number of blocks estimated in hours.
-    uint256 private constant PRICE_VALIDITY_DURATION = 18000; // 25 hours at 5 seconds per block
-
     /// Use this variable in case decimal value need to be evaluated
     uint8 private constant TOKEN_DECIMALS = 18;
-
 
     /*
      *  Storage
      */
     /// Private variable price
     uint256 private price;
-    /// blockheight at which the price expires
-    uint256 private oracleExpirationHeight;
-    /// specifies the base currency value e.g. "OST"
     bytes3 private oracleBaseCurrency;
-    /// specifies the quote Currency value "USD", "EUR", "ETH", "BTC"
     bytes3 private oracleQuoteCurrency;
 
     /*
@@ -58,15 +48,12 @@ contract PriceOracle is OpsManaged, PriceOracleInterface {
     /// @dev constructor function
     /// @param _baseCurrency baseCurrency
     /// @param _quoteCurrency quoteCurrency
-    function PriceOracle(
+    function PriceOracleMock(
         bytes3 _baseCurrency,
         bytes3 _quoteCurrency
         )
         public
-        OpsManaged()
     {
-        // base Currency and quote Currency should not be same
-        require(_baseCurrency != _quoteCurrency);
         // Initialize quote currency
         oracleQuoteCurrency = _quoteCurrency;
         // Initialize base currency
@@ -75,40 +62,28 @@ contract PriceOracle is OpsManaged, PriceOracleInterface {
 
     /// @dev use this method to set price
     /// @param _price price
-    /// @return expirationHeight
+    /// @return uint256
     function setPrice(
         uint256 _price)
         external
-        onlyOps
         returns(
-        uint256 /* expirationHeight */)
+        uint256)
     {
-        // Validate if _price is greater than 0
-        require(_price > 0);
-
         // Assign the new value
         price = _price;
 
-        // update the expiration height
-        oracleExpirationHeight = block.number + priceValidityDuration();
-
-        // Event Emitted
-        PriceUpdated(_price, oracleExpirationHeight);
-
-        // Return
-        return (oracleExpirationHeight);
+        return 0;
     }
 
-    /// @dev use this function to get quoteCurrency/baseCurrency value
-    /// @return price (Return 0 in case price expired so that call of this method can handle the error case)
+    /// @dev gets price
+    /// @return price
     function getPrice()
         public
         view
         returns (
         uint256 /* price */  )
     {
-        // Current Block Number should be less than expiration height
-        return (block.number > oracleExpirationHeight) ? 0 : price;
+        return price;
     }
 
     /// @dev use this function to get token decimals value
@@ -122,26 +97,24 @@ contract PriceOracle is OpsManaged, PriceOracleInterface {
         return TOKEN_DECIMALS;
     }
 
-    /// @dev use this function to get price validity duration
-    /// @return price validity duration
+    /// @dev returns 0
     function priceValidityDuration()
         public
         view
         returns(
-        uint256 /* price validity duration */)
+        uint256)
     {
-        return PRICE_VALIDITY_DURATION;
+        return 0;
     }
 
-    /// @dev block height at which the price expires
-    /// @return oracleExpirationHeight
+    /// @dev returns 0
     function expirationHeight()
         public
         view
         returns(
-        uint256 /* oracleExpirationHeight */)
+        uint256)
     {
-        return oracleExpirationHeight;
+        return 0;
     }
 
     /// @dev get baseCurrency bytes3 code

--- a/contracts/Pricer.sol
+++ b/contracts/Pricer.sol
@@ -25,7 +25,7 @@ pragma solidity ^0.4.17;
 
 import "./openst-protocol/EIP20Interface.sol";
 import "./openst-protocol/UtilityTokenInterface.sol";
-import "./ost-price-oracle/PriceOracleInterface.sol";
+import "./PriceOracleInterface.sol";
 import "./OpsManaged.sol";
 import "./SafeMath.sol";
 import "./PricerInterface.sol";

--- a/test/contracts/airdrop/airdrop_utils.js
+++ b/test/contracts/airdrop/airdrop_utils.js
@@ -24,7 +24,7 @@ const Utils          = require('../../lib/utils.js'),
       Workers        = artifacts.require('./Workers.sol'),
       Airdrop        = artifacts.require('./Airdrop.sol'),
       EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol'),
-      PriceOracle    = artifacts.require('./ost-price-oracle/PriceOracle.sol')
+      PriceOracle    = artifacts.require('./PriceOracleMock.sol')
       ;
 
 const ost = 'OST',
@@ -51,21 +51,18 @@ module.exports.deployAirdrop = async (artifacts, accounts) => {
         airdropBudgetHolder = accounts[3],
         workers             = await Workers.new(),
         airdrop             = await Airdrop.new(token.address, ost, workers.address, airdropBudgetHolder),
-        abcPriceOracle      = await PriceOracle.new(ost, abc),
-        abcPrice            = new BigNumber(20 * 10**18)
+        abcPrice            = new BigNumber(20 * 10**18),
+        abcPriceOracle      = await PriceOracle.new(ost, abc, abcPrice)
         ;
 
   assert.ok(await workers.setOpsAddress(opsAddress));
   assert.ok(await airdrop.setOpsAddress(opsAddress));
-  assert.ok(await abcPriceOracle.setOpsAddress(opsAddress));
 
   assert.ok(await workers.setWorker(worker, web3.eth.blockNumber + 1000, { from: opsAddress }));
   assert.ok(await airdrop.setPriceOracle(abc, abcPriceOracle.address, { from: opsAddress }));
-  assert.ok(await abcPriceOracle.setPrice(abcPrice, { from: opsAddress }));
 
   return {
     token          : token,
-    airdrop        : airdrop,
-    abcPriceOracle : abcPriceOracle
+    airdrop        : airdrop
   };
 };

--- a/test/contracts/pricer/base.js
+++ b/test/contracts/pricer/base.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils                               = require('./pricer_utils.js'),
+const pricerUtils                               = require('./pricer_utils.js'),
       constructor                                = require('./constructor.js'),
       properties                                 = require('./properties.js'),
       set_price_oracle                           = require('./set_price_oracle.js'),
@@ -27,7 +27,8 @@ const pricer_utils                               = require('./pricer_utils.js'),
       set_accepted_margin                        = require('./set_accepted_margin.js'),
       get_price_point                            = require('./get_price_point.js'),
       get_price_point_and_calculated_amounts     = require('./get_price_point_and_calculated_amounts.js'),
-      pay                                        = require('./pay.js');
+      pay                                        = require('./pay.js')
+      ;
 
 contract('Pricer', function(accounts) {
   // TODO: include PricerMock that wraps getBTAmountFromCurrencyValue and isPricePointInRange
@@ -41,8 +42,8 @@ contract('Pricer', function(accounts) {
   describe('GetPricePointAndCalculatedAmounts', async () => get_price_point_and_calculated_amounts.perform(accounts));
   describe('Pay', async () => pay.perform(accounts));
   after(async () => {
-    pricer_utils.utils.printGasStatistics();
-    pricer_utils.utils.clearReceipts();
+    pricerUtils.utils.printGasStatistics();
+    pricerUtils.utils.clearReceipts();
   });
   
 });

--- a/test/contracts/pricer/constructor.js
+++ b/test/contracts/pricer/constructor.js
@@ -19,9 +19,10 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils   = require('./pricer_utils.js'),
+const pricerUtils   = require('./pricer_utils.js'),
       Pricer         = artifacts.require('./Pricer.sol'),
-      EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol');
+      EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol')
+      ;
 
 ///
 /// Test stories
@@ -31,23 +32,24 @@ const pricer_utils   = require('./pricer_utils.js'),
 /// successfully deploys
 
 module.exports.perform = () => {
-  var token    = null;
-  var response = null;
+  var token    = null,
+      response = null
+      ;
 
   before(async () => {
-    token = await EIP20TokenMock.new(1, pricer_utils.currencies.ost, 'name', 18);
+    token = await EIP20TokenMock.new(1, pricerUtils.currencies.ost, 'name', 18);
   });
 
   it('fails to deploy if brandedToken is null', async () => {
-    await pricer_utils.utils.expectThrow(Pricer.new(0, pricer_utils.currencies.ost));
+    await pricerUtils.utils.expectThrow(Pricer.new(0, pricerUtils.currencies.ost));
   });
 
   it('fails to deploy if baseCurrency is empty', async () => {
-    await pricer_utils.utils.expectThrow(Pricer.new(token.address, ''));
+    await pricerUtils.utils.expectThrow(Pricer.new(token.address, ''));
   });
 
   it('successfully deploys', async () => {
-    response = await Pricer.new(token.address, pricer_utils.currencies.ost);
-    pricer_utils.utils.logTransaction(response.transactionHash, 'Pricer.constructor');
+    response = await Pricer.new(token.address, pricerUtils.currencies.ost);
+    pricerUtils.utils.logTransaction(response.transactionHash, 'Pricer.constructor');
   });
 }

--- a/test/contracts/pricer/get_price_point.js
+++ b/test/contracts/pricer/get_price_point.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js');
 
 ///
 /// Test stories
@@ -29,28 +29,27 @@ const pricer_utils = require('./pricer_utils.js');
 
 module.exports.perform = (accounts) => {
   const opsAddress = accounts[1],
-        usdPrice   = new pricer_utils.bigNumber(20 * 10**18),
-        eurPrice   = new pricer_utils.bigNumber(10 * 10**18);
+        abcPrice   = new pricerUtils.bigNumber(20 * 10**18),
+        xyzPrice   = new pricerUtils.bigNumber(10 * 10**18)
+        ;
 
   var response = null;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts      = await pricerUtils.deployPricer(artifacts, accounts);
     pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    eurPriceOracle = contracts.eurPriceOracle;     
-    await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
-    await usdPriceOracle.setPrice(usdPrice);
-    await eurPriceOracle.setPrice(eurPrice);
+    abcPriceOracle = contracts.abcPriceOracle;
+    xyzPriceOracle = contracts.xyzPriceOracle;
+    await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
+    await pricer.setPriceOracle(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress });
   });
 
   it('fails if priceOracle is not set', async () => {
-    await pricer_utils.utils.expectThrow(pricer.getPricePoint.call(pricer_utils.currencies.ost));
+    await pricerUtils.utils.expectThrow(pricer.getPricePoint.call(pricerUtils.currencies.ost));
   });
 
   it('successfully returns price from priceOracle', async () => {
-    assert.equal((await pricer.getPricePoint.call(pricer_utils.currencies.usd)).toNumber(), usdPrice);
-    assert.equal((await pricer.getPricePoint.call(pricer_utils.currencies.eur)).toNumber(), eurPrice);
+    assert.equal((await pricer.getPricePoint.call(pricerUtils.currencies.abc)).toNumber(), abcPrice);
+    assert.equal((await pricer.getPricePoint.call(pricerUtils.currencies.xyz)).toNumber(), xyzPrice);
   });
 }

--- a/test/contracts/pricer/get_price_point.js
+++ b/test/contracts/pricer/get_price_point.js
@@ -41,8 +41,8 @@ module.exports.perform = (accounts) => {
     eurPriceOracle = contracts.eurPriceOracle;     
     await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
     await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
-    await usdPriceOracle.setPrice(usdPrice, { from: opsAddress });
-    await eurPriceOracle.setPrice(eurPrice, { from: opsAddress });
+    await usdPriceOracle.setPrice(usdPrice);
+    await eurPriceOracle.setPrice(eurPrice);
   });
 
   it('fails if priceOracle is not set', async () => {

--- a/test/contracts/pricer/get_price_point_and_calculated_amounts.js
+++ b/test/contracts/pricer/get_price_point_and_calculated_amounts.js
@@ -44,7 +44,7 @@ module.exports.perform = (accounts) => {
     eurPriceOracle = contracts.eurPriceOracle;     
     await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
     await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
-    await eurPriceOracle.setPrice(eurPrice, { from: opsAddress });
+    await eurPriceOracle.setPrice(eurPrice);
   });
 
   it('fails to get pricePoint and calculated amounts if currency is empty', async () => {
@@ -65,7 +65,7 @@ module.exports.perform = (accounts) => {
 
   it('successfully gets pricePoints and calculated amounts', async () => {
     // set usdPriceOracle price
-    await usdPriceOracle.setPrice(usdPrice, { from: opsAddress });
+    await usdPriceOracle.setPrice(usdPrice);
 
     var returns = await pricer.getPricePointAndCalculatedAmounts.call(
       transferAmount, commissionAmount, pricer_utils.currencies.usd);

--- a/test/contracts/pricer/get_price_point_and_calculated_amounts.js
+++ b/test/contracts/pricer/get_price_point_and_calculated_amounts.js
@@ -19,65 +19,72 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js'),
+      PriceOracle = artifacts.require('./PriceOracleMock.sol')
+      ;
 
 ///
 /// Test stories
 ///
 /// fails to get pricePoint and calculated amounts if currency is empty
 /// fails to get pricePoint and calculated amounts if priceOracle is not set
-/// fails to get pricePoint and calculated amounts if pricePoint is 0
 /// successfully gets pricePoints and calculated amounts
+/// when oracle returns 0 for price
+///   fails to get pricePoint and calculated amounts
 
 module.exports.perform = (accounts) => {
   const opsAddress       = accounts[1],
-        usdPrice         = new pricer_utils.bigNumber(20 * 10**18),
-        eurPrice         = new pricer_utils.bigNumber(10 * 10**18),
+        abcPrice         = new pricerUtils.bigNumber(20 * 10**18),
+        xyzPrice         = new pricerUtils.bigNumber(10 * 10**18),
         conversionRate   = 10,
-        transferAmount   = new pricer_utils.bigNumber(5 * 10**18),
-        commissionAmount = new pricer_utils.bigNumber(1.25 * 10**18);
+        transferAmount   = new pricerUtils.bigNumber(5 * 10**18),
+        commissionAmount = new pricerUtils.bigNumber(1.25 * 10**18)
+        ;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
-    pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    eurPriceOracle = contracts.eurPriceOracle;     
-    await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
-    await eurPriceOracle.setPrice(eurPrice);
+    contracts       = await pricerUtils.deployPricer(artifacts, accounts);
+    pricer          = contracts.pricer;
+    zeroPriceOracle = contracts.abcPriceOracle;
+    xyzPriceOracle  = contracts.xyzPriceOracle;
+    await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
+    await pricer.setPriceOracle(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress });
   });
 
   it('fails to get pricePoint and calculated amounts if currency is empty', async () => {
-    await pricer_utils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
+    await pricerUtils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
       transferAmount, commissionAmount, ''));
   });
 
   it('fails to get pricePoint and calculated amounts if priceOracle is not set', async () => {
-    await pricer_utils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
-      transferAmount, commissionAmount, pricer_utils.currencies.ost));
-  });
-
-  it('fails to get pricePoint and calculated amounts if pricePoint is 0', async () => {
-    // usdPriceOracle price is not yet set, so will return 0 for pricePoint
-    await pricer_utils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
-      transferAmount, commissionAmount, pricer_utils.currencies.usd));
+    await pricerUtils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
+      transferAmount, commissionAmount, pricerUtils.currencies.ost));
   });
 
   it('successfully gets pricePoints and calculated amounts', async () => {
-    // set usdPriceOracle price
-    await usdPriceOracle.setPrice(usdPrice);
+    var returns = await pricer.getPricePointAndCalculatedAmounts.call(
+      transferAmount, commissionAmount, pricerUtils.currencies.abc);
+    assert.equal(returns[0].toNumber(), abcPrice.toNumber());
+    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(2.5 * 10**18));
+    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(0.625 * 10**18));
 
     var returns = await pricer.getPricePointAndCalculatedAmounts.call(
-      transferAmount, commissionAmount, pricer_utils.currencies.usd);
-    assert.equal(returns[0].toNumber(), usdPrice.toNumber());
-    assert.equal(returns[1].toNumber(), new pricer_utils.bigNumber(2.5 * 10**18));
-    assert.equal(returns[2].toNumber(), new pricer_utils.bigNumber(0.625 * 10**18));
-
-    var returns = await pricer.getPricePointAndCalculatedAmounts.call(
-      transferAmount, commissionAmount, pricer_utils.currencies.eur);
-    assert.equal(returns[0].toNumber(), eurPrice.toNumber());
-    assert.equal(returns[1].toNumber(), new pricer_utils.bigNumber(5 * 10**18));
-    assert.equal(returns[2].toNumber(), new pricer_utils.bigNumber(1.25 * 10**18));
+      transferAmount, commissionAmount, pricerUtils.currencies.xyz);
+    assert.equal(returns[0].toNumber(), xyzPrice.toNumber());
+    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(5 * 10**18));
+    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(1.25 * 10**18));
   });
 
+  context('when oracle returns 0 for price', async () => {
+    var zeroPriceOracle = null;
+
+    before(async () => {
+      zeroPriceOracle = await PriceOracle.new(pricerUtils.currencies.ost, 'OOO', 0);
+      await pricer.setPriceOracle('OOO', zeroPriceOracle.address, { from: opsAddress });
+    });
+
+    it('fails to get pricePoint and calculated amounts if pricePoint is 0', async () => {
+      await pricerUtils.utils.expectThrow(pricer.getPricePointAndCalculatedAmounts.call(
+        transferAmount, commissionAmount, 'OOO'));
+    });
+  });
 }

--- a/test/contracts/pricer/pay.js
+++ b/test/contracts/pricer/pay.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js');
 
 ///
 /// Test stories
@@ -27,53 +27,55 @@ const pricer_utils = require('./pricer_utils.js');
 /// fails to pay if beneficiary is null
 /// fails to pay if _transferAmount is 0
 /// fails to pay if _commissionAmount > 0 and _commissionBeneficiary is null
+/// successfully pays
 /// when currency is not empty
 ///   fails to pay if pricePoint is not > 0
 ///   fails to pay if pricePoint is not in range
-/// succesfully pays
+///   successfully pays
 
 module.exports.perform = (accounts) => {
   const opsAddress            = accounts[1],
-        usdPrice              = new pricer_utils.bigNumber(20 * 10**18),
+        abcPrice              = new pricerUtils.bigNumber(20 * 10**18),
         conversionRate        = 10,
-        transferAmount        = new pricer_utils.bigNumber(5 * 10**18),
-        commissionAmount      = new pricer_utils.bigNumber(1.25 * 10**18),
+        transferAmount        = new pricerUtils.bigNumber(5 * 10**18),
+        commissionAmount      = new pricerUtils.bigNumber(1.25 * 10**18),
         beneficiary           = accounts[2],
-        commissionBeneficiary = accounts[3];
+        commissionBeneficiary = accounts[3]
+        ;
 
   var response           = null,
-      intendedPricePoint = null;
+      intendedPricePoint = null
+      ;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts      = await pricerUtils.deployPricer(artifacts, accounts);
     token          = contracts.token;
     pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    await usdPriceOracle.setPrice(usdPrice);
-    intendedPricePoint = await pricer.getPricePoint.call(pricer_utils.currencies.usd);
-    await token.setBalance(accounts[0], new pricer_utils.bigNumber(100 * 10**18));
+    abcPriceOracle = contracts.abcPriceOracle;
+    await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
+    intendedPricePoint = await pricer.getPricePoint.call(pricerUtils.currencies.abc);
+    await token.setBalance(accounts[0], new pricerUtils.bigNumber(100 * 10**18));
   });
 
 	it('fails to pay if beneficiary is null', async () => {
     await token.approve(pricer.address, transferAmount.plus(commissionAmount));
-    await pricer_utils.utils.expectThrow(pricer.pay.call(
+    await pricerUtils.utils.expectThrow(pricer.pay.call(
       0, transferAmount, commissionBeneficiary, commissionAmount, '', intendedPricePoint));
   });
 
   it('fails to pay if _transferAmount is 0', async () => {
     await token.approve(pricer.address, transferAmount.plus(commissionAmount));
-    await pricer_utils.utils.expectThrow(pricer.pay.call(
+    await pricerUtils.utils.expectThrow(pricer.pay.call(
       beneficiary, 0, commissionBeneficiary, commissionAmount, '', intendedPricePoint));
   });
 
   it('fails to pay if _commissionAmount > 0 and _commissionBeneficiary is null', async () => {
     await token.approve(pricer.address, transferAmount.plus(commissionAmount));
-    await pricer_utils.utils.expectThrow(pricer.pay.call(
+    await pricerUtils.utils.expectThrow(pricer.pay.call(
       beneficiary, transferAmount, 0, commissionAmount, '', intendedPricePoint));
   });
 
-  it('succesfully pays', async () => {
+  it('successfully pays', async () => {
     // without commission
     await token.setBalance(beneficiary, 0);
     assert.equal(await token.balanceOf.call(beneficiary), 0);
@@ -84,7 +86,7 @@ module.exports.perform = (accounts) => {
     assert.equal((await token.balanceOf(beneficiary)).toNumber(), transferAmount);
     // When currency is blank, transferAmount is equal to tokenAmount
     checkPaymentEvent(response.logs[0], beneficiary, transferAmount, 0, 0, '', 0);
-    pricer_utils.utils.logResponse(response, 'Pricer.pay: ' + transferAmount);
+    pricerUtils.utils.logResponse(response, 'Pricer.pay: ' + transferAmount);
 
     // with commission
     // reset token balances to 0
@@ -100,18 +102,18 @@ module.exports.perform = (accounts) => {
     assert.equal((await token.balanceOf(commissionBeneficiary)).toNumber(), commissionAmount);
     // When currency is blank, transferAmount is equal to tokenAmount
     checkPaymentEvent(response.logs[0], beneficiary, transferAmount, commissionBeneficiary, commissionAmount, '', 0);
-    pricer_utils.utils.logResponse(response, 'Pricer.pay: ' + transferAmount.plus(commissionAmount));
+    pricerUtils.utils.logResponse(response, 'Pricer.pay: ' + transferAmount.plus(commissionAmount));
   });
 
   context('when currency is not empty', async () => {
     it('fails to pay if pricePoint is not > 0', async () => {
-      await pricer_utils.utils.expectThrow(pricer.pay.call(
-        beneficiary, transferAmount, 0, 0, pricer_utils.currencies.eur, intendedPricePoint));
+      await pricerUtils.utils.expectThrow(pricer.pay.call(
+        beneficiary, transferAmount, 0, 0, pricerUtils.currencies.xyz, intendedPricePoint));
     });
 
     it('fails to pay if pricePoint is not in range', async () => {
-      await pricer_utils.utils.expectThrow(pricer.pay.call(
-        beneficiary, transferAmount, 0, 0, pricer_utils.currencies.usd, intendedPricePoint.plus(1)));
+      await pricerUtils.utils.expectThrow(pricer.pay.call(
+        beneficiary, transferAmount, 0, 0, pricerUtils.currencies.abc, intendedPricePoint.plus(1)));
     });
 
     it('successfully pays', async () => {
@@ -121,18 +123,18 @@ module.exports.perform = (accounts) => {
 
       // get amount of tokens from currency value
       var calculatedResponse = (await pricer.getPricePointAndCalculatedAmounts.call(
-      transferAmount, commissionAmount, pricer_utils.currencies.usd));
+      transferAmount, commissionAmount, pricerUtils.currencies.abc));
 
       var convertedTokenTransferAmount = calculatedResponse[1];
 
       await token.approve(pricer.address, convertedTokenTransferAmount);
-      assert.ok(await pricer.pay.call(beneficiary, transferAmount, 0, 0, pricer_utils.currencies.usd, intendedPricePoint));
-      response = await pricer.pay(beneficiary, transferAmount, 0, 0, pricer_utils.currencies.usd, intendedPricePoint);
+      assert.ok(await pricer.pay.call(beneficiary, transferAmount, 0, 0, pricerUtils.currencies.abc, intendedPricePoint));
+      response = await pricer.pay(beneficiary, transferAmount, 0, 0, pricerUtils.currencies.abc, intendedPricePoint);
       assert.equal((await token.balanceOf(beneficiary)).toNumber(), convertedTokenTransferAmount);
 
       // Note: Payment event publishes unconverted values--this is OK because the Transfer event will show convertedTransferAmount
-      checkPaymentEvent(response.logs[0], beneficiary, convertedTokenTransferAmount, 0, 0, pricer_utils.currencies.usd, intendedPricePoint);
-      pricer_utils.utils.logResponse(response, 'Pricer.pay (currency): ' + transferAmount);
+      checkPaymentEvent(response.logs[0], beneficiary, convertedTokenTransferAmount, 0, 0, pricerUtils.currencies.abc, intendedPricePoint);
+      pricerUtils.utils.logResponse(response, 'Pricer.pay (currency): ' + transferAmount);
     });
 
   });

--- a/test/contracts/pricer/pay.js
+++ b/test/contracts/pricer/pay.js
@@ -50,7 +50,7 @@ module.exports.perform = (accounts) => {
     pricer         = contracts.pricer;
     usdPriceOracle = contracts.usdPriceOracle;
     await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    await usdPriceOracle.setPrice(usdPrice, { from: opsAddress });
+    await usdPriceOracle.setPrice(usdPrice);
     intendedPricePoint = await pricer.getPricePoint.call(pricer_utils.currencies.usd);
     await token.setBalance(accounts[0], new pricer_utils.bigNumber(100 * 10**18));
   });

--- a/test/contracts/pricer/pricer_utils.js
+++ b/test/contracts/pricer/pricer_utils.js
@@ -23,7 +23,7 @@ const Utils          = require('../../lib/utils.js'),
       BigNumber      = require('bignumber.js'),
       Pricer         = artifacts.require('./Pricer.sol'),
       EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol'),
-    	PriceOracle    = artifacts.require('./ost-price-oracle/PriceOracle.sol');
+    	PriceOracle    = artifacts.require('./PriceOracleMock.sol');
 
 const ost = 'OST',
       usd = 'USD',
@@ -50,8 +50,6 @@ module.exports.deployPricer = async (artifacts, accounts) => {
         eurPriceOracle = await PriceOracle.new(ost, eur);
 
   assert.ok(await pricer.setOpsAddress(opsAddress));
-  assert.ok(await usdPriceOracle.setOpsAddress(opsAddress));
-  assert.ok(await eurPriceOracle.setOpsAddress(opsAddress));
 
 	return {
     token          : token,

--- a/test/contracts/pricer/pricer_utils.js
+++ b/test/contracts/pricer/pricer_utils.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // ----------------------------------------------------------------------------
-// Test: pricer_utils.js
+// Test: pricerUtils.js
 //
 // http://www.simpletoken.org/
 //
@@ -23,11 +23,13 @@ const Utils          = require('../../lib/utils.js'),
       BigNumber      = require('bignumber.js'),
       Pricer         = artifacts.require('./Pricer.sol'),
       EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol'),
-    	PriceOracle    = artifacts.require('./PriceOracleMock.sol');
+    	PriceOracle    = artifacts.require('./PriceOracleMock.sol')
+      ;
 
 const ost = 'OST',
-      usd = 'USD',
-      eur = 'EUR';
+      abc = 'ABC',
+      xyz = 'XYZ'
+      ;
 
 /// @dev Export common requires
 module.exports.utils     = Utils;
@@ -36,8 +38,8 @@ module.exports.bigNumber = BigNumber;
 /// @dev Export constants
 module.exports.currencies = {
   ost : ost,
-  usd : usd,
-  eur : eur
+  abc : abc,
+  xyz : xyz
 }
 
 /// @dev Deploy
@@ -46,15 +48,18 @@ module.exports.deployPricer = async (artifacts, accounts) => {
         TOKEN_DECIMALS = 18,
         opsAddress     = accounts[1],
         pricer         = await Pricer.new(token.address, ost),
-        usdPriceOracle = await PriceOracle.new(ost, usd),
-        eurPriceOracle = await PriceOracle.new(ost, eur);
+        abcPrice       = new BigNumber(20 * 10**18),
+        xyzPrice       = new BigNumber(10 * 10**18),
+        abcPriceOracle = await PriceOracle.new(ost, abc, abcPrice),
+        xyzPriceOracle = await PriceOracle.new(ost, xyz, xyzPrice)
+        ;
 
   assert.ok(await pricer.setOpsAddress(opsAddress));
 
 	return {
     token          : token,
     pricer         : pricer,
-    usdPriceOracle : usdPriceOracle,
-    eurPriceOracle : eurPriceOracle
+    abcPriceOracle : abcPriceOracle,
+    xyzPriceOracle : xyzPriceOracle
 	};
 };

--- a/test/contracts/pricer/properties.js
+++ b/test/contracts/pricer/properties.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js');
 
 ///
 /// Test stories
@@ -31,10 +31,11 @@ const pricer_utils = require('./pricer_utils.js');
 
 module.exports.perform = (accounts) => {
   const TOKEN_DECIMALS = 18,
-        conversionRate = 10;
+        conversionRate = 10
+        ;
 
   before(async () => {
-    contracts   = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts   = await pricerUtils.deployPricer(artifacts, accounts);
     token       = contracts.token;
     pricer      = contracts.pricer;
   });
@@ -44,7 +45,7 @@ module.exports.perform = (accounts) => {
   });
 
   it('has baseCurrency', async () => {
-    assert.equal(web3.toAscii(await pricer.baseCurrency.call()), pricer_utils.currencies.ost);
+    assert.equal(web3.toAscii(await pricer.baseCurrency.call()), pricerUtils.currencies.ost);
   });
 
   it('has decimals', async () => {

--- a/test/contracts/pricer/set_accepted_margin.js
+++ b/test/contracts/pricer/set_accepted_margin.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js');
 
 ///
 /// Test stories
@@ -31,43 +31,43 @@ module.exports.perform = (accounts) => {
   const opsAddress = accounts[1];
 
   var response       = null,
-      acceptedMargin = null;
+      acceptedMargin = null
+      ;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts      = await pricerUtils.deployPricer(artifacts, accounts);
     pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    eurPriceOracle = contracts.eurPriceOracle;     
-    await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
+    abcPriceOracle = contracts.abcPriceOracle;
+    await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
   });
 
   it('fails to set acceptedMargin by non-ops', async () => {
     acceptedMargin = 1;
-    await pricer_utils.utils.expectThrow(pricer.setAcceptedMargin.call(pricer_utils.currencies.usd, acceptedMargin));
+    await pricerUtils.utils.expectThrow(pricer.setAcceptedMargin.call(pricerUtils.currencies.abc, acceptedMargin));
   });
 
   it('successfully sets acceptedMargin', async () => {
     // Sets accepted margin multiple times to show range of gas usages
-    acceptedMargin = new pricer_utils.bigNumber(0);
-    assert.ok(await pricer.setAcceptedMargin.call(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress }));
-    response = await pricer.setAcceptedMargin(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress });
-    assert.equal((await pricer.acceptedMargins.call(pricer_utils.currencies.usd)).toNumber(), acceptedMargin.toNumber());
-    checkAcceptedMarginSetEvent(response.logs[0], pricer_utils.currencies.usd, acceptedMargin);
-    pricer_utils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
+    acceptedMargin = new pricerUtils.bigNumber(0);
+    assert.ok(await pricer.setAcceptedMargin.call(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress }));
+    response = await pricer.setAcceptedMargin(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress });
+    assert.equal((await pricer.acceptedMargins.call(pricerUtils.currencies.abc)).toNumber(), acceptedMargin.toNumber());
+    checkAcceptedMarginSetEvent(response.logs[0], pricerUtils.currencies.abc, acceptedMargin);
+    pricerUtils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
 
-    acceptedMargin = new pricer_utils.bigNumber(1);
-    assert.ok(await pricer.setAcceptedMargin.call(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress }));
-    response = await pricer.setAcceptedMargin(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress });
-    assert.equal((await pricer.acceptedMargins.call(pricer_utils.currencies.usd)).toNumber(), acceptedMargin.toNumber());
-    checkAcceptedMarginSetEvent(response.logs[0], pricer_utils.currencies.usd, acceptedMargin);
-    pricer_utils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
+    acceptedMargin = new pricerUtils.bigNumber(1);
+    assert.ok(await pricer.setAcceptedMargin.call(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress }));
+    response = await pricer.setAcceptedMargin(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress });
+    assert.equal((await pricer.acceptedMargins.call(pricerUtils.currencies.abc)).toNumber(), acceptedMargin.toNumber());
+    checkAcceptedMarginSetEvent(response.logs[0], pricerUtils.currencies.abc, acceptedMargin);
+    pricerUtils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
 
-    acceptedMargin = new pricer_utils.bigNumber(7.778 * 10**17); // 10**17 to ease readability in gas usage output
-    assert.ok(await pricer.setAcceptedMargin.call(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress }));
-    response = await pricer.setAcceptedMargin(pricer_utils.currencies.usd, acceptedMargin, { from: opsAddress });
-    assert.equal((await pricer.acceptedMargins.call(pricer_utils.currencies.usd)).toNumber(), acceptedMargin.toNumber());
-    checkAcceptedMarginSetEvent(response.logs[0], pricer_utils.currencies.usd, acceptedMargin);
-    pricer_utils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
+    acceptedMargin = new pricerUtils.bigNumber(7.778 * 10**17); // 10**17 to ease readability in gas usage output
+    assert.ok(await pricer.setAcceptedMargin.call(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress }));
+    response = await pricer.setAcceptedMargin(pricerUtils.currencies.abc, acceptedMargin, { from: opsAddress });
+    assert.equal((await pricer.acceptedMargins.call(pricerUtils.currencies.abc)).toNumber(), acceptedMargin.toNumber());
+    checkAcceptedMarginSetEvent(response.logs[0], pricerUtils.currencies.abc, acceptedMargin);
+    pricerUtils.utils.logResponse(response, 'Pricer.setAcceptedMargin: ' + acceptedMargin);
   });
 }
 

--- a/test/contracts/pricer/set_price_oracle.js
+++ b/test/contracts/pricer/set_price_oracle.js
@@ -58,7 +58,7 @@ module.exports.perform = (accounts) => {
   });
 
   it('fails to set priceOracle if oracle baseCurrency does not match pricer baseCurrency', async () => {
-    var inappositeOracle = await PriceOracle.new(pricerUtils.currencies.abc, pricerUtils.currencies.ost);
+    var inappositeOracle = await PriceOracle.new(pricerUtils.currencies.abc, pricerUtils.currencies.ost, 1);
     await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call(
       pricerUtils.currencies.abc, inappositeOracle.address, { from: opsAddress }));
   });

--- a/test/contracts/pricer/set_price_oracle.js
+++ b/test/contracts/pricer/set_price_oracle.js
@@ -19,8 +19,9 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js'),
-      PriceOracle = artifacts.require('./PriceOracleMock.sol');
+const pricerUtils = require('./pricer_utils.js'),
+      PriceOracle = artifacts.require('./PriceOracleMock.sol')
+      ;
 
 ///
 /// Test stories
@@ -38,46 +39,46 @@ module.exports.perform = (accounts) => {
   var response = null;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts      = await pricerUtils.deployPricer(artifacts, accounts);
     pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    eurPriceOracle = contracts.eurPriceOracle;     
+    abcPriceOracle = contracts.abcPriceOracle;
+    xyzPriceOracle = contracts.xyzPriceOracle;     
   });
 
   it('fails to set priceOracle by non-ops', async () => {
-    await pricer_utils.utils.expectThrow(pricer.setPriceOracle.call(pricer_utils.currencies.usd, usdPriceOracle.address));
+    await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call(pricerUtils.currencies.abc, abcPriceOracle.address));
   });
 
   it('fails to set priceOracle if oracleAddress is null', async () => {
-    await pricer_utils.utils.expectThrow(pricer.setPriceOracle.call(pricer_utils.currencies.usd, 0, { from: opsAddress }));
+    await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call(pricerUtils.currencies.abc, 0, { from: opsAddress }));
   });
 
   it('fails to set priceOracle if currency is empty', async () => {
-    await pricer_utils.utils.expectThrow(pricer.setPriceOracle.call('', usdPriceOracle.address, { from: opsAddress }));
+    await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call('', abcPriceOracle.address, { from: opsAddress }));
   });
 
   it('fails to set priceOracle if oracle baseCurrency does not match pricer baseCurrency', async () => {
-    var inappositeOracle = await PriceOracle.new(pricer_utils.currencies.usd, pricer_utils.currencies.ost);
-    await pricer_utils.utils.expectThrow(pricer.setPriceOracle.call(
-      pricer_utils.currencies.usd, inappositeOracle.address, { from: opsAddress }));
+    var inappositeOracle = await PriceOracle.new(pricerUtils.currencies.abc, pricerUtils.currencies.ost);
+    await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call(
+      pricerUtils.currencies.abc, inappositeOracle.address, { from: opsAddress }));
   });
 
   it('fails to set priceOracle if oracle quoteCurrency does not match currency', async () => {
-    await pricer_utils.utils.expectThrow(pricer.setPriceOracle.call(pricer_utils.currencies.eur, usdPriceOracle.address));
+    await pricerUtils.utils.expectThrow(pricer.setPriceOracle.call(pricerUtils.currencies.xyz, abcPriceOracle.address));
   });
 
   it('successfully sets priceOracles', async () => {
-    assert.ok(await pricer.setPriceOracle.call(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress }));
-    response = await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    assert.equal(await pricer.priceOracles.call(pricer_utils.currencies.usd), usdPriceOracle.address);
-    checkPriceOracleSetEvent(response.logs[0], pricer_utils.currencies.usd, usdPriceOracle.address);
-    pricer_utils.utils.logResponse(response, 'Pricer.setPriceOracle: ' + pricer_utils.currencies.usd);
+    assert.ok(await pricer.setPriceOracle.call(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress }));
+    response = await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
+    assert.equal(await pricer.priceOracles.call(pricerUtils.currencies.abc), abcPriceOracle.address);
+    checkPriceOracleSetEvent(response.logs[0], pricerUtils.currencies.abc, abcPriceOracle.address);
+    pricerUtils.utils.logResponse(response, 'Pricer.setPriceOracle: ' + pricerUtils.currencies.abc);
 
-    assert.ok(await pricer.setPriceOracle.call(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress }));
-    response = await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
-    assert.equal(await pricer.priceOracles.call(pricer_utils.currencies.eur), eurPriceOracle.address);
-    checkPriceOracleSetEvent(response.logs[0], pricer_utils.currencies.eur, eurPriceOracle.address);
-    pricer_utils.utils.logResponse(response, 'Pricer.setPriceOracle: ' + pricer_utils.currencies.eur);
+    assert.ok(await pricer.setPriceOracle.call(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress }));
+    response = await pricer.setPriceOracle(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress });
+    assert.equal(await pricer.priceOracles.call(pricerUtils.currencies.xyz), xyzPriceOracle.address);
+    checkPriceOracleSetEvent(response.logs[0], pricerUtils.currencies.xyz, xyzPriceOracle.address);
+    pricerUtils.utils.logResponse(response, 'Pricer.setPriceOracle: ' + pricerUtils.currencies.xyz);
   });
 }
 

--- a/test/contracts/pricer/set_price_oracle.js
+++ b/test/contracts/pricer/set_price_oracle.js
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 const pricer_utils = require('./pricer_utils.js'),
-      PriceOracle = artifacts.require('./PriceOracle.sol');
+      PriceOracle = artifacts.require('./PriceOracleMock.sol');
 
 ///
 /// Test stories

--- a/test/contracts/pricer/unset_price_oracle.js
+++ b/test/contracts/pricer/unset_price_oracle.js
@@ -19,7 +19,7 @@
 //
 // ----------------------------------------------------------------------------
 
-const pricer_utils = require('./pricer_utils.js');
+const pricerUtils = require('./pricer_utils.js');
 
 ///
 /// Test stories
@@ -34,31 +34,31 @@ module.exports.perform = (accounts) => {
   var response = null;
 
   before(async () => {
-    contracts      = await pricer_utils.deployPricer(artifacts, accounts);
+    contracts      = await pricerUtils.deployPricer(artifacts, accounts);
     pricer         = contracts.pricer;
-    usdPriceOracle = contracts.usdPriceOracle;
-    eurPriceOracle = contracts.eurPriceOracle;     
-    await pricer.setPriceOracle(pricer_utils.currencies.usd, usdPriceOracle.address, { from: opsAddress });
-    await pricer.setPriceOracle(pricer_utils.currencies.eur, eurPriceOracle.address, { from: opsAddress });
+    abcPriceOracle = contracts.abcPriceOracle;
+    xyzPriceOracle = contracts.xyzPriceOracle;     
+    await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
+    await pricer.setPriceOracle(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress });
   });
 
   it('fails to set priceOracle by non-ops', async () => {
-    await pricer_utils.utils.expectThrow(pricer.unsetPriceOracle.call(pricer_utils.currencies.usd));
+    await pricerUtils.utils.expectThrow(pricer.unsetPriceOracle.call(pricerUtils.currencies.abc));
   });
 
   it('successfully unsets priceOracle', async () => {
-    assert.ok(await pricer.unsetPriceOracle.call(pricer_utils.currencies.usd, { from: opsAddress }));
-    response = await pricer.unsetPriceOracle(pricer_utils.currencies.usd, { from: opsAddress });
-    assert.equal(await pricer.priceOracles.call(pricer_utils.currencies.usd), 0);
-    checkPriceOracleUnsetEvent(response.logs[0], pricer_utils.currencies.usd);
-    pricer_utils.utils.logResponse(response, 'Pricer.unsetPriceOracle: ' + pricer_utils.currencies.usd);
+    assert.ok(await pricer.unsetPriceOracle.call(pricerUtils.currencies.abc, { from: opsAddress }));
+    response = await pricer.unsetPriceOracle(pricerUtils.currencies.abc, { from: opsAddress });
+    assert.equal(await pricer.priceOracles.call(pricerUtils.currencies.abc), 0);
+    checkPriceOracleUnsetEvent(response.logs[0], pricerUtils.currencies.abc);
+    pricerUtils.utils.logResponse(response, 'Pricer.unsetPriceOracle: ' + pricerUtils.currencies.abc);
 
     // confirm EUR priceOracle unaffected
-    assert.equal(await pricer.priceOracles.call(pricer_utils.currencies.eur), eurPriceOracle.address);
+    assert.equal(await pricer.priceOracles.call(pricerUtils.currencies.xyz), xyzPriceOracle.address);
   });
 
   it('fails to unset priceOracle if not already set', async () => {
-    await pricer_utils.utils.expectThrow(pricer.unsetPriceOracle.call(pricer_utils.currencies.usd, { from: opsAddress }));
+    await pricerUtils.utils.expectThrow(pricer.unsetPriceOracle.call(pricerUtils.currencies.abc, { from: opsAddress }));
   });
 }
 


### PR DESCRIPTION
- corrects the license in PriceOracleInterface
- implements a `PriceOracleMock` that adheres to the present testing in of `Pricer`, and so does not necessarily take care of #19.
- removes the `ost-price-oracle` directory

🚨 Because of changes to `Pricer` events, tests are not all green—this will be resolved in #56.