### PR TITLE
Update Pricer to consume conversionRateDecimals

### DIFF
--- a/contracts/EIP20TokenMock.sol
+++ b/contracts/EIP20TokenMock.sol
@@ -29,6 +29,7 @@ import "./openst-protocol/EIP20Token.sol";
 /// @title EIP20TokenMock - Provides EIP20Token with mock functionality to facilitate testing payments 
 contract EIP20TokenMock is EIP20Token {
     uint256 public conversionRate;
+    uint8 public conversionRateDecimals;
 
     /// @dev    Takes _conversionRate, _symbol, _name, _decimals
     /// @param _conversionRate conversionRate
@@ -37,6 +38,7 @@ contract EIP20TokenMock is EIP20Token {
     /// @param _decimals decimals
     function EIP20TokenMock(
         uint256 _conversionRate,
+        uint8 _conversionRateDecimals,
         string _symbol,
         string _name,
         uint8 _decimals)
@@ -45,6 +47,7 @@ contract EIP20TokenMock is EIP20Token {
         public
     {
         conversionRate = _conversionRate;
+        conversionRateDecimals = _conversionRateDecimals;
     }
 
     /// @dev    Returns 0 as mock total supply

--- a/contracts/Pricer.sol
+++ b/contracts/Pricer.sol
@@ -52,8 +52,11 @@ contract Pricer is OpsManaged, PricerInterface {
     /// Pricer decimal
     uint8 private pricerDecimals;
 
-    /// conversionRate 
+    /// conversionRate
     uint256 private pricerConversionRate;
+
+    /// conversionRateDecimals
+    uint8 private pricerConversionRateDecimals;
 
     /*
      *  Public functions
@@ -75,6 +78,7 @@ contract Pricer is OpsManaged, PricerInterface {
         pricerBaseCurrency = _baseCurrency;
         pricerDecimals = EIP20Interface(pricerBrandedToken).decimals();
         pricerConversionRate = UtilityTokenInterface(_brandedToken).conversionRate();
+        pricerConversionRateDecimals = UtilityTokenInterface(_brandedToken).conversionRateDecimals();
     }
 
     /*
@@ -135,9 +139,9 @@ contract Pricer is OpsManaged, PricerInterface {
         return pricerBaseCurrency;
     }
 
-    /// @dev    Returns pricer decimal;
+    /// @dev    Returns pricer decimal for branded token;
     ///         public method;
-    /// @return bytes3    
+    /// @return uint8    
     function decimals() 
         public
         returns (uint8)
@@ -145,14 +149,24 @@ contract Pricer is OpsManaged, PricerInterface {
         return pricerDecimals;
     }
 
-    /// @dev    Returns conversion rate;
+    /// @dev    Returns conversion rate for branded token;
     ///         public method;
-    /// @return bytes3    
+    /// @return uint256    
     function conversionRate() 
         public
         returns (uint256)
     {
         return pricerConversionRate;
+    }
+
+    /// @dev    Returns conversion rate decimals for branded token;
+    ///         public method;
+    /// @return uint8    
+    function conversionRateDecimals() 
+        public
+        returns (uint8)
+    {
+        return pricerConversionRateDecimals;
     }
 
     /// @dev    Takes _currency, _oracleAddress; 
@@ -357,7 +371,7 @@ contract Pricer is OpsManaged, PricerInterface {
         view
         returns (uint256, uint256) /* number of BT ,number of commission BT */
     {
-        uint256 adjConversionRate = SafeMath.mul(pricerConversionRate, 10**uint256(pricerDecimals));
+        uint256 adjConversionRate = SafeMath.div(SafeMath.mul(pricerConversionRate, 10**uint256(pricerDecimals)), 10**uint256(pricerConversionRateDecimals));
         uint256 amountBT = SafeMath.div(SafeMath.mul(_transferAmount, adjConversionRate), _pricePoint);
         uint256 commissionAmountBT = SafeMath.div(SafeMath.mul(_commissionAmount, adjConversionRate), _pricePoint);
         return (amountBT, commissionAmountBT);

--- a/contracts/Pricer.sol
+++ b/contracts/Pricer.sol
@@ -348,10 +348,10 @@ contract Pricer is OpsManaged, PricerInterface {
     {
         bool isValid = true;
         if (_intendedPricePoint >= _acceptedMargin) {
-            isValid = SafeMath.sub(_intendedPricePoint, _acceptedMargin) <= _currentPricePoint;
+            isValid = _intendedPricePoint.sub(_acceptedMargin) <= _currentPricePoint;
         }
         if (isValid) {
-            isValid = _currentPricePoint <= SafeMath.add(_intendedPricePoint, _acceptedMargin);
+            isValid = _currentPricePoint <= _intendedPricePoint.add(_acceptedMargin);
         }
         return isValid;     
     }
@@ -371,9 +371,9 @@ contract Pricer is OpsManaged, PricerInterface {
         view
         returns (uint256, uint256) /* number of BT ,number of commission BT */
     {
-        uint256 adjConversionRate = SafeMath.div(SafeMath.mul(pricerConversionRate, 10**uint256(pricerDecimals)), 10**uint256(pricerConversionRateDecimals));
-        uint256 amountBT = SafeMath.div(SafeMath.mul(_transferAmount, adjConversionRate), _pricePoint);
-        uint256 commissionAmountBT = SafeMath.div(SafeMath.mul(_commissionAmount, adjConversionRate), _pricePoint);
+        uint256 adjConversionRate = pricerConversionRate.mul(10**uint256(pricerDecimals)).div(10**uint256(pricerConversionRateDecimals));
+        uint256 amountBT = _transferAmount.mul(adjConversionRate).div(_pricePoint);
+        uint256 commissionAmountBT = _commissionAmount.mul(adjConversionRate).div(_pricePoint);
         return (amountBT, commissionAmountBT);
     }
 

--- a/contracts/Pricer.sol
+++ b/contracts/Pricer.sol
@@ -371,9 +371,9 @@ contract Pricer is OpsManaged, PricerInterface {
         view
         returns (uint256, uint256) /* number of BT ,number of commission BT */
     {
-        uint256 adjConversionRate = pricerConversionRate.mul(10**uint256(pricerDecimals)).div(10**uint256(pricerConversionRateDecimals));
-        uint256 amountBT = _transferAmount.mul(adjConversionRate).div(_pricePoint);
-        uint256 commissionAmountBT = _commissionAmount.mul(adjConversionRate).div(_pricePoint);
+        uint256 conversionRatetoBTWei = pricerConversionRate.mul(10**uint256(pricerDecimals)).div(10**uint256(pricerConversionRateDecimals));
+        uint256 amountBT = _transferAmount.mul(conversionRatetoBTWei).div(_pricePoint);
+        uint256 commissionAmountBT = _commissionAmount.mul(conversionRatetoBTWei).div(_pricePoint);
         return (amountBT, commissionAmountBT);
     }
 

--- a/contracts/PricerInterface.sol
+++ b/contracts/PricerInterface.sol
@@ -89,19 +89,26 @@ contract PricerInterface {
         public
         returns (bytes3);
 
-    /// @dev    Returns pricer decimal;
+    /// @dev    Returns pricer decimal for branded token;
     ///         public method;
-    /// @return bytes3    
+    /// @return uint8
     function decimals() 
         public
         returns (uint8);
 
-    /// @dev    Returns conversion rate;
+    /// @dev    Returns conversion rate for branded token;
     ///         public method;
-    /// @return bytes3    
-    function conversionRate() 
+    /// @return uint256
+    function conversionRate()
         public
         returns (uint256);
+
+    /// @dev    Returns conversion rate decimals for branded token;
+    ///         public method;
+    /// @return uint8
+    function conversionRateDecimals()
+        public
+        returns (uint8);
 
     /// @dev    Takes _currency, _oracleAddress; 
     ///         updates the price oracle address for a given currency;

--- a/contracts/openst-protocol/UtilityTokenInterface.sol
+++ b/contracts/openst-protocol/UtilityTokenInterface.sol
@@ -1,3 +1,4 @@
+/* solhint-disable-next-line compiler-fixed */
 pragma solidity ^0.4.17;
 
 // Copyright 2017 OpenST Ltd.
@@ -23,18 +24,20 @@ pragma solidity ^0.4.17;
 
 contract UtilityTokenInterface {
 
-	/// @dev transfer full claim to beneficiary
+    /// @dev transfer full claim to beneficiary
     function claim(address _beneficiary) public returns (bool success);
     /// @dev Mint new utility token into  claim for beneficiary
     function mint(address _beneficiary, uint256 _amount) public returns (bool success);
     /// @dev Burn utility tokens after having redeemed them
     ///      through the protocol for the staked Simple Token
     function burn(address _burner, uint256 _amount) public payable returns (bool success);
-   	
- 	/// @dev Get totalTokenSupply as view so that child cannot edit
-	function totalSupply() public view returns (uint256 supply);
+
+    /// @dev Get totalTokenSupply as view so that child cannot edit
+    function totalSupply() public view returns (uint256 supply);
     /// @dev Get unique universal identifier for utility token
     function uuid() public view returns (bytes32 getUuid);
-	/// @dev Get conversion rate for utility token
-	function conversionRate() public view returns (uint256 rate);
+    /// @dev Get conversion rate for utility token
+    function conversionRate() public view returns (uint256 rate);
+    /// @dev Get conversion rate decimal factor for utility token
+    function conversionRateDecimals() public view returns (uint8 rateDecimal);
 }

--- a/test/contracts/airdrop/airdrop_utils.js
+++ b/test/contracts/airdrop/airdrop_utils.js
@@ -44,15 +44,17 @@ module.exports.currencies = {
 /// @dev Deploy
 module.exports.deployAirdrop = async (artifacts, accounts) => {
 
-  const token               = await EIP20TokenMock.new(10, ost, 'name', 18),
-        TOKEN_DECIMALS      = 18,
-        opsAddress          = accounts[1],
-        worker              = accounts[2],
-        airdropBudgetHolder = accounts[3],
-        workers             = await Workers.new(),
-        airdrop             = await Airdrop.new(token.address, ost, workers.address, airdropBudgetHolder),
-        abcPrice            = new BigNumber(20 * 10**18),
-        abcPriceOracle      = await PriceOracle.new(ost, abc, abcPrice)
+  const conversionRate         = 101,
+        conversionRateDecimals = 1,
+        token                  = await EIP20TokenMock.new(conversionRate, conversionRateDecimals, ost, 'name', 18),
+        TOKEN_DECIMALS         = 18,
+        opsAddress             = accounts[1],
+        worker                 = accounts[2],
+        airdropBudgetHolder    = accounts[3],
+        workers                = await Workers.new(),
+        airdrop                = await Airdrop.new(token.address, ost, workers.address, airdropBudgetHolder),
+        abcPrice               = new BigNumber(20 * 10**18),
+        abcPriceOracle         = await PriceOracle.new(ost, abc, abcPrice)
         ;
 
   assert.ok(await workers.setOpsAddress(opsAddress));

--- a/test/contracts/airdrop/constructor.js
+++ b/test/contracts/airdrop/constructor.js
@@ -39,7 +39,7 @@ module.exports.perform = (accounts) => {
   var token = null;
 
   before(async () => {
-    token = await EIP20TokenMock.new(1, airdropUtils.currencies.ost, 'name', 18);
+    token = await EIP20TokenMock.new(1, 0, airdropUtils.currencies.ost, 'name', 18);
   });
 
   it('fails to deploy if workers is null', async () => {

--- a/test/contracts/airdrop/pay_airdrop.js
+++ b/test/contracts/airdrop/pay_airdrop.js
@@ -46,7 +46,9 @@ module.exports.perform = (accounts) => {
         airdropAmount         = new airdropUtils.bigNumber(10 * 10**18)
         ;
 
-  var airdrop               = null,
+  var contracts             = null,
+      token                 = null,
+      airdrop               = null,
       response              = null
       ;
 

--- a/test/contracts/pricer/constructor.js
+++ b/test/contracts/pricer/constructor.js
@@ -37,7 +37,7 @@ module.exports.perform = () => {
       ;
 
   before(async () => {
-    token = await EIP20TokenMock.new(1, pricerUtils.currencies.ost, 'name', 18);
+    token = await EIP20TokenMock.new(1, 0, pricerUtils.currencies.ost, 'name', 18);
   });
 
   it('fails to deploy if brandedToken is null', async () => {

--- a/test/contracts/pricer/get_price_point.js
+++ b/test/contracts/pricer/get_price_point.js
@@ -33,7 +33,12 @@ module.exports.perform = (accounts) => {
         xyzPrice   = new pricerUtils.bigNumber(10 * 10**18)
         ;
 
-  var response = null;
+  var contracts      = null,
+      pricer         = null,
+      abcPriceOracle = null,
+      xyzPriceOracle = null,
+      response       = null
+      ;
 
   before(async () => {
     contracts      = await pricerUtils.deployPricer(artifacts, accounts);

--- a/test/contracts/pricer/get_price_point_and_calculated_amounts.js
+++ b/test/contracts/pricer/get_price_point_and_calculated_amounts.js
@@ -33,12 +33,12 @@ const pricerUtils = require('./pricer_utils.js'),
 ///   fails to get pricePoint and calculated amounts
 
 module.exports.perform = (accounts) => {
-  const opsAddress       = accounts[1],
-        abcPrice         = new pricerUtils.bigNumber(20 * 10**18),
-        xyzPrice         = new pricerUtils.bigNumber(10 * 10**18),
-        conversionRate   = 10,
-        transferAmount   = new pricerUtils.bigNumber(5 * 10**18),
-        commissionAmount = new pricerUtils.bigNumber(1.25 * 10**18)
+  const opsAddress             = accounts[1],
+        abcPrice               = new pricerUtils.bigNumber(20 * 10**18),
+        xyzPrice               = new pricerUtils.bigNumber(10 * 10**18),
+        conversionRate         = 101,
+        transferAmount         = new pricerUtils.bigNumber(5 * 10**18),
+        commissionAmount       = new pricerUtils.bigNumber(1.25 * 10**18)
         ;
 
   before(async () => {
@@ -64,14 +64,14 @@ module.exports.perform = (accounts) => {
     var returns = await pricer.getPricePointAndCalculatedAmounts.call(
       transferAmount, commissionAmount, pricerUtils.currencies.abc);
     assert.equal(returns[0].toNumber(), abcPrice.toNumber());
-    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(2.5 * 10**18));
-    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(0.625 * 10**18));
+    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(2.525 * 10**18));
+    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(0.63125 * 10**18));
 
     var returns = await pricer.getPricePointAndCalculatedAmounts.call(
       transferAmount, commissionAmount, pricerUtils.currencies.xyz);
     assert.equal(returns[0].toNumber(), xyzPrice.toNumber());
-    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(5 * 10**18));
-    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(1.25 * 10**18));
+    assert.equal(returns[1].toNumber(), new pricerUtils.bigNumber(5.05 * 10**18));
+    assert.equal(returns[2].toNumber(), new pricerUtils.bigNumber(1.2625 * 10**18));
   });
 
   context('when oracle returns 0 for price', async () => {

--- a/test/contracts/pricer/get_price_point_and_calculated_amounts.js
+++ b/test/contracts/pricer/get_price_point_and_calculated_amounts.js
@@ -36,15 +36,20 @@ module.exports.perform = (accounts) => {
   const opsAddress             = accounts[1],
         abcPrice               = new pricerUtils.bigNumber(20 * 10**18),
         xyzPrice               = new pricerUtils.bigNumber(10 * 10**18),
-        conversionRate         = 101,
         transferAmount         = new pricerUtils.bigNumber(5 * 10**18),
         commissionAmount       = new pricerUtils.bigNumber(1.25 * 10**18)
         ;
 
+  var contracts      = null,
+      pricer         = null,
+      abcPriceOracle = null,
+      xyzPriceOracle = null
+      ;
+
   before(async () => {
     contracts       = await pricerUtils.deployPricer(artifacts, accounts);
     pricer          = contracts.pricer;
-    zeroPriceOracle = contracts.abcPriceOracle;
+    abcPriceOracle = contracts.abcPriceOracle;
     xyzPriceOracle  = contracts.xyzPriceOracle;
     await pricer.setPriceOracle(pricerUtils.currencies.abc, abcPriceOracle.address, { from: opsAddress });
     await pricer.setPriceOracle(pricerUtils.currencies.xyz, xyzPriceOracle.address, { from: opsAddress });

--- a/test/contracts/pricer/pay.js
+++ b/test/contracts/pricer/pay.js
@@ -36,14 +36,17 @@ const pricerUtils = require('./pricer_utils.js');
 module.exports.perform = (accounts) => {
   const opsAddress            = accounts[1],
         abcPrice              = new pricerUtils.bigNumber(20 * 10**18),
-        conversionRate        = 10,
         transferAmount        = new pricerUtils.bigNumber(5 * 10**18),
         commissionAmount      = new pricerUtils.bigNumber(1.25 * 10**18),
         beneficiary           = accounts[2],
         commissionBeneficiary = accounts[3]
         ;
 
-  var response           = null,
+  var contracts          = null,
+      token              = null,
+      pricer             = null,
+      abcPriceOracle     = null,
+      response           = null,
       intendedPricePoint = null
       ;
 

--- a/test/contracts/pricer/pricer_utils.js
+++ b/test/contracts/pricer/pricer_utils.js
@@ -44,14 +44,16 @@ module.exports.currencies = {
 
 /// @dev Deploy
 module.exports.deployPricer = async (artifacts, accounts) => {
-  const token          = await EIP20TokenMock.new(10, ost, 'name', 18),
-        TOKEN_DECIMALS = 18,
-        opsAddress     = accounts[1],
-        pricer         = await Pricer.new(token.address, ost),
-        abcPrice       = new BigNumber(20 * 10**18),
-        xyzPrice       = new BigNumber(10 * 10**18),
-        abcPriceOracle = await PriceOracle.new(ost, abc, abcPrice),
-        xyzPriceOracle = await PriceOracle.new(ost, xyz, xyzPrice)
+  const conversionRate         = 101,
+        conversionRateDecimals = 1,
+        token                  = await EIP20TokenMock.new(conversionRate, conversionRateDecimals, ost, 'name', 18),
+        TOKEN_DECIMALS         = 18,
+        opsAddress             = accounts[1],
+        pricer                 = await Pricer.new(token.address, ost),
+        abcPrice               = new BigNumber(20 * 10**18),
+        xyzPrice               = new BigNumber(10 * 10**18),
+        abcPriceOracle         = await PriceOracle.new(ost, abc, abcPrice),
+        xyzPriceOracle         = await PriceOracle.new(ost, xyz, xyzPrice)
         ;
 
   assert.ok(await pricer.setOpsAddress(opsAddress));

--- a/test/contracts/pricer/properties.js
+++ b/test/contracts/pricer/properties.js
@@ -35,6 +35,11 @@ module.exports.perform = (accounts) => {
         conversionRateDecimals = 1
         ;
 
+  var contracts      = null,
+      token          = null,
+      pricer         = null
+      ;
+
   before(async () => {
     contracts   = await pricerUtils.deployPricer(artifacts, accounts);
     token       = contracts.token;

--- a/test/contracts/pricer/properties.js
+++ b/test/contracts/pricer/properties.js
@@ -31,7 +31,8 @@ const pricerUtils = require('./pricer_utils.js');
 
 module.exports.perform = (accounts) => {
   const TOKEN_DECIMALS = 18,
-        conversionRate = 10
+        conversionRate = 101,
+        conversionRateDecimals = 1
         ;
 
   before(async () => {
@@ -54,5 +55,9 @@ module.exports.perform = (accounts) => {
 
   it('has conversionRate', async () => {
     assert.equal((await pricer.conversionRate.call()).toNumber(), conversionRate);
+  });
+
+  it('has conversionRateDecimals', async () => {
+    assert.equal((await pricer.conversionRateDecimals.call()).toNumber(), conversionRateDecimals);
   });
 }

--- a/test/contracts/pricer/set_accepted_margin.js
+++ b/test/contracts/pricer/set_accepted_margin.js
@@ -30,8 +30,11 @@ const pricerUtils = require('./pricer_utils.js');
 module.exports.perform = (accounts) => {
   const opsAddress = accounts[1];
 
-  var response       = null,
-      acceptedMargin = null
+  var contracts      = null,
+      pricer         = null,
+      abcPriceOracle = null,
+      acceptedMargin = null,
+      response       = null
       ;
 
   before(async () => {

--- a/test/contracts/pricer/set_price_oracle.js
+++ b/test/contracts/pricer/set_price_oracle.js
@@ -36,7 +36,12 @@ const pricerUtils = require('./pricer_utils.js'),
 module.exports.perform = (accounts) => {
   const opsAddress = accounts[1];
 
-  var response = null;
+  var contracts      = null,
+      pricer         = null,
+      abcPriceOracle = null,
+      xyzPriceOracle = null,
+      response       = null
+      ;
 
   before(async () => {
     contracts      = await pricerUtils.deployPricer(artifacts, accounts);

--- a/test/contracts/pricer/unset_price_oracle.js
+++ b/test/contracts/pricer/unset_price_oracle.js
@@ -31,7 +31,12 @@ const pricerUtils = require('./pricer_utils.js');
 module.exports.perform = (accounts) => {
   const opsAddress = accounts[1];
 
-  var response = null;
+  var contracts      = null,
+      pricer         = null,
+      abcPriceOracle = null,
+      xyzPriceOracle = null,
+      response       = null
+      ;
 
   before(async () => {
     contracts      = await pricerUtils.deployPricer(artifacts, accounts);

--- a/test/contracts/workers/remove.js
+++ b/test/contracts/workers/remove.js
@@ -35,7 +35,7 @@ module.exports.perform = (accounts) => {
         adminAddress        = accounts[2]
         ;
 
-  var workers = null,
+  var workers  = null,
       response = null
       ;
 

--- a/test/contracts/workers/remove_worker.js
+++ b/test/contracts/workers/remove_worker.js
@@ -39,6 +39,10 @@ module.exports.perform = (accounts) => {
         height2             = new workersUtils.bigNumber(1000)
         ;
         
+  var workers            = null,
+      deactivationHeight = null
+      ;
+
   before(async () => {
     workers = await Workers.new();
     assert.ok(await workers.setOpsAddress(opsAddress));

--- a/test/contracts/workers/set_is_worker.js
+++ b/test/contracts/workers/set_is_worker.js
@@ -45,7 +45,9 @@ module.exports.perform = (accounts) => {
         height2               = new workersUtils.bigNumber(1000)
         ;
 
-  var deactivationHeight = null;
+  var workers            = null,
+      deactivationHeight = null
+      ;
 
   before(async () => {
 


### PR DESCRIPTION
Updates `Pricer` to consume `conversionRateDecimals`:
- uses updated `UtilityTokenInterface`
- incorporates `conversionRateDecimals` into `Pricer` and interface
  - sets/gets
  - updates `getBTAmountFromCurrencyValue`
- fixes/modifies certain commenets
- updates tests to reflect changed conversion maths
- refactors `Pricer`
- refactors truffle tests

Assigning to @benjaminbollen, because I'm not sure if new thinking about the conversion impacts the merging of this PR, but requesting @deepesh-kn's review.

🚨 This **will** break interaction layer testing because `EIP20TokenMock`'s constructor was updated to take a `conversionRateDecimal` argument, cc: @abhayks1 