### PR TITLE
Add script for installing geth v. 1.7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo apt-get install software-properties-common
   - sudo add-apt-repository -y ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get install ethereum
+  - sudo bash mocha_test/scripts/install_geth_1_7_3.sh
   - sudo apt-get install solc
   - geth version
 install: 

--- a/mocha_test/scripts/geth_checker.js
+++ b/mocha_test/scripts/geth_checker.js
@@ -8,7 +8,7 @@ const rootPrefix = '../..'
 const performer = async function () {
 
   const delay = 10 * 1000
-    , timeoutValue = 5 * 60 * 1000
+    , timeoutValue = 30 * 60 * 1000
   ;
 
   var counter = 0
@@ -21,7 +21,7 @@ const performer = async function () {
       if (isInProcess == false) {
         isInProcess = true;
         web3RpcProvider.eth.getBlockNumber(function (err, blocknumber) {
-          if (err) {
+          if (err || blocknumber < 1) {
             logger.info("Unable to get blocknumber");
           } else {
             logger.info("blocknumber", blocknumber);

--- a/mocha_test/scripts/install_geth_1_7_3.sh
+++ b/mocha_test/scripts/install_geth_1_7_3.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+curl https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz | tar xvz
+mv geth-linux-amd64-1.7.3-4bb3c89d /usr/local/bin
+ln -s /usr/local/bin/geth-linux-amd64-1.7.3-4bb3c89d/geth /usr/local/bin/geth
+export PATH="$PATH:/usr/local/bin/geth-linux-amd64-1.7.3-4bb3c89d"


### PR DESCRIPTION
Adds script for installing geth v. 1.7.3.

- adds script for installing geth v. 1.7.3 to rollback until https://github.com/ethereum/go-ethereum/issues/16092 is addressed
- adjusts `geth_checker.js` to wait for a non-0 block number and with a timeout of 30min (to accommodate a long DAG generation process)