### PR TITLE
Fixing broken tests

### DIFF
--- a/contracts/truffle/Migrations.sol
+++ b/contracts/truffle/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/test/contracts/airdrop/airdrop_utils.js
+++ b/test/contracts/airdrop/airdrop_utils.js
@@ -24,8 +24,9 @@ const Utils          = require('../../lib/utils.js'),
       Workers        = artifacts.require('./Workers.sol'),
       Airdrop        = artifacts.require('./Airdrop.sol'),
       EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol'),
-      PriceOracle    = artifacts.require('./PriceOracleMock.sol')
-      ;
+      PriceOracle    = artifacts.require('./PriceOracleMock.sol'),
+      Web3 = require('web3'),
+      web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
 const ost = 'OST',
       abc = 'ABC'
@@ -59,8 +60,8 @@ module.exports.deployAirdrop = async (artifacts, accounts) => {
 
   assert.ok(await workers.setOpsAddress(opsAddress));
   assert.ok(await airdrop.setOpsAddress(opsAddress));
-
-  assert.ok(await workers.setWorker(worker, web3.eth.blockNumber + 1000, { from: opsAddress }));
+  let blockNumber = await web3.eth.getBlockNumber();
+  assert.ok(await workers.setWorker(worker, blockNumber + 1000, { from: opsAddress }));
   assert.ok(await airdrop.setPriceOracle(abc, abcPriceOracle.address, { from: opsAddress }));
 
   return {

--- a/test/contracts/airdrop/airdrop_utils.js
+++ b/test/contracts/airdrop/airdrop_utils.js
@@ -25,8 +25,7 @@ const Utils          = require('../../lib/utils.js'),
       Airdrop        = artifacts.require('./Airdrop.sol'),
       EIP20TokenMock = artifacts.require('./EIP20TokenMock.sol'),
       PriceOracle    = artifacts.require('./PriceOracleMock.sol'),
-      Web3 = require('web3'),
-      web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+      web3 = require('../../lib/web3') ;
 
 const ost = 'OST',
       abc = 'ABC'

--- a/test/contracts/workers/remove.js
+++ b/test/contracts/workers/remove.js
@@ -21,9 +21,8 @@
 
 const workersUtils = require('./workers_utils.js'),
   Workers = artifacts.require('./Workers.sol'),
-  Web3 = require('web3'),
-  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
-;
+  web3 = require('../../lib/web3') ;
+
 
 ///
 /// Test stories

--- a/test/contracts/workers/remove.js
+++ b/test/contracts/workers/remove.js
@@ -19,9 +19,11 @@
 //
 // ----------------------------------------------------------------------------
 
-const workersUtils   = require('./workers_utils.js'),
-      Workers        = artifacts.require('./Workers.sol')
-      ;
+const workersUtils = require('./workers_utils.js'),
+  Workers = artifacts.require('./Workers.sol'),
+  Web3 = require('web3'),
+  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+;
 
 ///
 /// Test stories
@@ -31,13 +33,13 @@ const workersUtils   = require('./workers_utils.js'),
 /// successfully removes when sender is adminAddress
 
 module.exports.perform = (accounts) => {
-  const opsAddress          = accounts[1],
-        adminAddress        = accounts[2]
-        ;
+  const opsAddress = accounts[1],
+    adminAddress = accounts[2]
+  ;
 
-  var workers  = null,
-      response = null
-      ;
+  var workers = null,
+    response = null
+  ;
 
   beforeEach(async () => {
 
@@ -49,34 +51,35 @@ module.exports.perform = (accounts) => {
 
   it('fails to remove when sender is neither opsAddress nor adminAddress', async () => {
 
-    await workersUtils.utils.expectThrow(workers.remove.call({ from: accounts[3] }));
+    await workersUtils.utils.expectThrow(workers.remove.call({from: accounts[3]}));
 
   });
 
   it('successfully removes when sender is opsAddress', async () => {
 
     // call remove
-    assert.ok(await workers.remove.call({ from: opsAddress }));
-    response = await workers.remove({ from: opsAddress });
+    assert.ok(await workers.remove.call({from: opsAddress}));
+    response = await workers.remove({from: opsAddress});
     workersUtils.utils.logResponse(response, 'Workers.remove (ops)');
 
     // check if contract is removed
-    assert.equal(web3.eth.getCode(workers.address),0x0);
+    let code = await web3.eth.getCode(workers.address);
+    assert.equal(code, 0x0);
 
   });
 
   it('successfully removes when sender is adminAddress', async () => {
 
     // call remove from admin address
-    assert.ok(await workers.remove.call({ from: adminAddress }));
-    response = await workers.remove({ from: adminAddress });
+    assert.ok(await workers.remove.call({from: adminAddress}));
+    response = await workers.remove({from: adminAddress});
     workersUtils.utils.logResponse(response, 'Workers.remove (admin)');
 
     // check if contract is removed
-    assert.equal(web3.eth.getCode(workers.address),0x0);
+    let code = await web3.eth.getCode(workers.address);
+    assert.equal(code, 0x0);
 
   });
-
 }
 
 

--- a/test/contracts/workers/remove_worker.js
+++ b/test/contracts/workers/remove_worker.js
@@ -19,9 +19,11 @@
 //
 // ----------------------------------------------------------------------------
 
-const workersUtils   = require('./workers_utils.js'),
-      Workers        = artifacts.require('./Workers.sol')
-      ;
+const workersUtils = require('./workers_utils.js'),
+  Workers = artifacts.require('./Workers.sol'),
+  Web3 = require('web3'),
+  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+;
 
 ///
 /// Test stories
@@ -31,44 +33,45 @@ const workersUtils   = require('./workers_utils.js'),
 /// pass to remove worker
 
 module.exports.perform = (accounts) => {
-  const opsAddress          = accounts[1],
-        worker1Address      =  accounts[2],
-        worker2Address      =  accounts[3],
-        worker3Address      =  accounts[4],
-        height1             = new workersUtils.bigNumber(500),
-        height2             = new workersUtils.bigNumber(1000)
-        ;
-        
-  var workers            = null,
-      deactivationHeight = null
-      ;
+  const opsAddress = accounts[1],
+    worker1Address = accounts[2],
+    worker2Address = accounts[3],
+    worker3Address = accounts[4],
+    height1 = new workersUtils.bigNumber(500),
+    height2 = new workersUtils.bigNumber(1000)
+  ;
+
+  var workers = null,
+    deactivationHeight = null
+  ;
 
   before(async () => {
     workers = await Workers.new();
     assert.ok(await workers.setOpsAddress(opsAddress));
 
     // set worker 1
-    deactivationHeight = web3.eth.blockNumber + height1.toNumber();
-    await workers.setWorker(worker1Address, deactivationHeight, { from: opsAddress });
-
+    let blockNumber = await web3.eth.getBlockNumber();
+    deactivationHeight = blockNumber + height1.toNumber();
+    await workers.setWorker(worker1Address, deactivationHeight, {from: opsAddress});
+    blockNumber = await web3.eth.getBlockNumber();
     // set worker 2
-    deactivationHeight = web3.eth.blockNumber + height2.toNumber();
-    await workers.setWorker(worker2Address, deactivationHeight, { from: opsAddress });
+    deactivationHeight = blockNumber + height2.toNumber();
+    await workers.setWorker(worker2Address, deactivationHeight, {from: opsAddress});
 
   });
 
 
   it('fails to remove worker if sender is not opsAddress', async () => {
 
-    await workersUtils.utils.expectThrow(workers.removeWorker.call(worker1Address, { from: accounts[5] }));
+    await workersUtils.utils.expectThrow(workers.removeWorker.call(worker1Address, {from: accounts[5]}));
 
   });
 
 
   it('fails to remove worker if worker was not set', async () => {
 
-    assert.equal(await workers.removeWorker.call(worker3Address, { from: opsAddress }), false);
-    response = await workers.removeWorker(worker3Address, { from: opsAddress });
+    assert.equal(await workers.removeWorker.call(worker3Address, {from: opsAddress}), false);
+    response = await workers.removeWorker(worker3Address, {from: opsAddress});
     assert.equal(await workers.isWorker.call(worker3Address), false);
     workersUtils.checkWorkerRemovedEvent(response.logs[0], worker3Address, false);
     workersUtils.utils.logResponse(response, 'Workers.removeWorker (never set)');
@@ -78,20 +81,20 @@ module.exports.perform = (accounts) => {
 
   it('pass to remove worker', async () => {
 
-    assert.equal(await workers.removeWorker.call(worker1Address, { from: opsAddress }), true);
-    response = await workers.removeWorker(worker1Address, { from: opsAddress });
+    assert.equal(await workers.removeWorker.call(worker1Address, {from: opsAddress}), true);
+    response = await workers.removeWorker(worker1Address, {from: opsAddress});
     assert.equal(await workers.isWorker.call(worker1Address), false);
     workersUtils.checkWorkerRemovedEvent(response.logs[0], worker1Address, true);
     workersUtils.utils.logResponse(response, 'Workers.removeWorker (w1)');
 
-    assert.equal(await workers.removeWorker.call(worker2Address, { from: opsAddress }), true);
-    response = await workers.removeWorker(worker2Address, { from: opsAddress });
+    assert.equal(await workers.removeWorker.call(worker2Address, {from: opsAddress}), true);
+    response = await workers.removeWorker(worker2Address, {from: opsAddress});
     assert.equal(await workers.isWorker.call(worker2Address), false);
     workersUtils.checkWorkerRemovedEvent(response.logs[0], worker2Address, true);
     workersUtils.utils.logResponse(response, 'Workers.removeWorker (w2)');
 
-    assert.equal(await workers.removeWorker.call(worker2Address, { from: opsAddress }), false);
-    response = await workers.removeWorker(worker2Address, { from: opsAddress });
+    assert.equal(await workers.removeWorker.call(worker2Address, {from: opsAddress}), false);
+    response = await workers.removeWorker(worker2Address, {from: opsAddress});
     assert.equal(await workers.isWorker.call(worker2Address), false);
     workersUtils.checkWorkerRemovedEvent(response.logs[0], worker2Address, false);
     workersUtils.utils.logResponse(response, 'Workers.removeWorker (w1 again)');

--- a/test/contracts/workers/remove_worker.js
+++ b/test/contracts/workers/remove_worker.js
@@ -21,9 +21,7 @@
 
 const workersUtils = require('./workers_utils.js'),
   Workers = artifacts.require('./Workers.sol'),
-  Web3 = require('web3'),
-  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
-;
+  web3 = require('../../lib/web3') ;
 
 ///
 /// Test stories

--- a/test/contracts/workers/set_is_worker.js
+++ b/test/contracts/workers/set_is_worker.js
@@ -21,9 +21,7 @@
 
 const workersUtils = require('./workers_utils.js'),
   Workers = artifacts.require('./Workers.sol'),
-  Web3 = require('web3'),
-  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
-;
+  web3 = require('../../lib/web3') ;
 
 ///
 /// Test stories

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -23,8 +23,10 @@ const Assert = require('assert');
 
 const NullAddress = "0x0000000000000000000000000000000000000000";
 const rootPrefix = '../..'
-  , logger = require(rootPrefix + '/helpers/custom_console_logger');
-
+  , logger = require(rootPrefix + '/helpers/custom_console_logger'),
+  Web3 = require('web3'),
+  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+;
 /*
  *  Tracking Gas Usage
  */

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -24,8 +24,7 @@ const Assert = require('assert');
 const NullAddress = "0x0000000000000000000000000000000000000000";
 const rootPrefix = '../..'
   , logger = require(rootPrefix + '/helpers/custom_console_logger'),
-  Web3 = require('web3'),
-  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+  web3 = require('./web3');
 ;
 /*
  *  Tracking Gas Usage

--- a/test/lib/web3.js
+++ b/test/lib/web3.js
@@ -1,0 +1,7 @@
+"use strict";
+
+
+const Web3 = require('web3'),
+  web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+
+module.exports = web3;


### PR DESCRIPTION
Openst-payments build pipeline was broken due to failing tests. 

1. With upgraded web3 version, web3 instance is not explicitly available.  
2. Few sync methods like web3.eth.blockNumber are not working, it has now changed to an async call. 
